### PR TITLE
산업공학과, 공과대학 크롤러를 추가합니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "axios": "^0.21.1",
     "cheerio": "^1.0.0-rc.5",
     "lodash": "^4.17.20",
+    "nanoid": "^3.1.20",
     "path-parser": "^6.1.0"
   },
   "devDependencies": {
@@ -49,6 +50,7 @@
     "lint-staged": "^10.2.11",
     "prettier": "^2.0.5",
     "serverless": "^2.22.0",
+    "serverless-domain-manager": "^5.1.0",
     "serverless-dynamodb-local": "^0.2.39",
     "serverless-offline": "^6.8.0",
     "serverless-prune-plugin": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "cheerio": "^1.0.0-rc.5",
     "lodash": "^4.17.20",
     "nanoid": "^3.1.20",
-    "path-parser": "^6.1.0"
+    "path-parser": "^6.1.0",
+    "ts-md5": "^1.2.7"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.71",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "lint": "eslint . --ext .ts,.tsx",
     "db:install": "serverless dynamodb install --stage dev",
     "db:remove": "serverless dynamodb remove --stage dev",
-    "dev": "node --max-old-space-size=512 node_modules/serverless/bin/serverless.js offline start --stage dev",
-    "deploy": "serverless deploy"
+    "dev": "node --max-old-space-size=1024 node_modules/serverless/bin/serverless.js offline start --stage dev",
+    "deploy:v1": "read -p \"[PRODUCTION WARNING]\nAre you sure deploying to v1?\nEnter stage again. \" -r\necho\nif [[ $REPLY =~ v1$ ]]\nthen serverless deploy -s v1\nfi",
+    "deploy:test": "serverless deploy -s test"
   },
   "dependencies": {
     "aws-lambda": "^1.0.6",

--- a/resources/domain.yml
+++ b/resources/domain.yml
@@ -1,5 +1,5 @@
 # If you want to use another domain, modify this file
+hostedzone: 'MTG05956633JZKOSFE37OZ' #pseudo
 
-# hostedzone: 'Z005956633JZKOSFE37OV'
 # Include ${opt:stage} if you want to use a different endpoint for each stage
-apiUrl: 'api.snuboard.io'
+apiUrl: 'api.snuboard.link'

--- a/resources/dynamodb.yml
+++ b/resources/dynamodb.yml
@@ -33,7 +33,7 @@ Resources:
         #   AttributeType: S
         # - AttributeName: name
         #   AttributeType: S
-        # - AttributeName: uri
+        # - AttributeName: url
         #   AttributeType: S
   DepartmentTable:
     Type: AWS::DynamoDB::Table
@@ -46,7 +46,7 @@ Resources:
       AttributeDefinitions:
         - AttributeName: id
           AttributeType: S
-        # - AttributeName: baseHref
+        # - AttributeName: url
         #   AttributeType: S
         # - AttributeName: name
         #   AttributeType: S

--- a/resources/dynamodb.yml
+++ b/resources/dynamodb.yml
@@ -5,19 +5,11 @@ Resources:
       TableName: ${self:custom.tables.notice}
       BillingMode: PAY_PER_REQUEST
       KeySchema:
-        - AttributeName: createdAt
+        - AttributeName: id
           KeyType: HASH
-        - AttributeName: title
-          KeyType: RANGE
       AttributeDefinitions:
-        - AttributeName: createdAt
+        - AttributeName: id
           AttributeType: S
-        - AttributeName: title
-          AttributeType: S
-        # - AttributeName: id
-        #   AttributeType: S
-        # - AttributeName: boardId
-        #   AttributeType: S
   BoardTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -29,12 +21,6 @@ Resources:
       AttributeDefinitions:
         - AttributeName: id
           AttributeType: S
-        # - AttributeName: departmentId
-        #   AttributeType: S
-        # - AttributeName: name
-        #   AttributeType: S
-        # - AttributeName: url
-        #   AttributeType: S
   DepartmentTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -46,7 +32,3 @@ Resources:
       AttributeDefinitions:
         - AttributeName: id
           AttributeType: S
-        # - AttributeName: url
-        #   AttributeType: S
-        # - AttributeName: name
-        #   AttributeType: S

--- a/resources/dynamodb.yml
+++ b/resources/dynamodb.yml
@@ -5,14 +5,16 @@ Resources:
       TableName: ${self:custom.tables.notice}
       BillingMode: PAY_PER_REQUEST
       KeySchema:
-        - AttributeName: id
+        - AttributeName: createdAt
           KeyType: HASH
+        - AttributeName: title
+          KeyType: RANGE
       AttributeDefinitions:
-        - AttributeName: id
+        - AttributeName: createdAt
           AttributeType: S
-        # - AttributeName: createdAt
-        #   AttributeType: S
-        # - AttributeName: title
+        - AttributeName: title
+          AttributeType: S
+        # - AttributeName: id
         #   AttributeType: S
         # - AttributeName: boardId
         #   AttributeType: S

--- a/serverless.yml
+++ b/serverless.yml
@@ -84,7 +84,7 @@ functions:
   crawl:
     handler: src/crawler/crawl.handler
     timeout: 60
-    memorySize: 512
+    memorySize: 320
     events:
       - schedule:
           rate: cron(0 10 * * ? *)

--- a/serverless.yml
+++ b/serverless.yml
@@ -40,37 +40,27 @@ provider:
   stage: ${opt:stage}
   region: ap-northeast-2
   environment:
-    HTTP_ENDPOINT:
-      {
-        'Fn::Join':
-          [
-            '',
-            [
-              'https://',
-              { 'Ref': 'ApiGatewayRestApi' },
-              '.execute-api.${self:provider.region}.amazonaws.com/${self:provider.stage}',
-            ],
-          ],
-      }
+    # HTTP_ENDPOINT:
+    #   {
+    #     'Fn::Join':
+    #       [
+    #         '',
+    #         [
+    #           'https://',
+    #           { 'Ref': 'ApiGatewayRestApi' },
+    #           '.execute-api.${self:provider.region}.amazonaws.com/${self:provider.stage}',
+    #         ],
+    #       ],
+    #   }
     STAGE: ${self:provider.stage}
     REGION: ${self:provider.region}
+    # Ports for dev
+    DEV_HTTP_PORT: ${self:custom.serverless-offline.httpPort}
+    DEV_LAMBDA_PORT: ${self:custom.serverless-offline.lambdaPort}
     # DynamoDB Table Names
     NOTICE_TABLE: ${self:custom.tables.notice}
     DEPARTMENT_TABLE: ${self:custom.tables.department}
     BOARD_TABLE: ${self:custom.tables.board}
-    # # VPC
-    # VPC:
-    #   Ref: VPC
-    # PUBLIC_SECURITY_GROUP:
-    #   Ref: SnuBoardPublicSecurityGroup
-    # PUBLIC_SUBNET_A:
-    #   Ref: PublicSubnetA
-    # PUBLIC_SUBNET_B:
-    #   Ref: PublicSubnetB
-    # PUBLIC_SUBNET_C:
-    #   Ref: PublicSubnetC
-    # PUBLIC_SUBNET_D:
-    #   Ref: PublicSubnetD
   timeout: 30
   iamRoleStatements:
     - Effect: Allow
@@ -87,12 +77,6 @@ provider:
               - Ref: AWS::Region
               - Ref: AWS::AccountId
               - function:*
-  # vpc:
-  #   securityGroupIds:
-  #     - Ref: SnuBoardSecurityGroup
-  #   subnetIds:
-  #     - Ref: PrivateSubnetA
-
 functions:
   # --- http ---
 
@@ -102,15 +86,9 @@ functions:
     timeout: 60
     memorySize: 512
     events:
-      - http:
-          method: any
-          cors: true
-          path: crawl
       - schedule:
           rate: cron(0 10 * * ? *)
           enabled: true
+
 resources:
   - ${file(resources/dynamodb.yml)}
-  # - ${file(resources/domain.yml)}
-  # - ${file(resources/network.yml)}
-  # - ${file(resources/iam.yml)}

--- a/src/crawler/crawl.ts
+++ b/src/crawler/crawl.ts
@@ -1,12 +1,11 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import middleware from './middleware';
+import { crawl } from './index';
 
 export const handler: APIGatewayProxyHandler = middleware(async () => {
-  try {
-    console.log('done');
-  } catch (e) {
-    console.log(e);
-  }
+  console.log('start crawl');
+  await crawl();
+  console.log('end crawl');
   return {
     statusCode: 200,
     body: 'ok',

--- a/src/crawler/index.ts
+++ b/src/crawler/index.ts
@@ -1,0 +1,170 @@
+import axios from 'axios';
+import * as cheerio from 'cheerio';
+import { chain } from 'lodash';
+import Board from '../utils/models/board';
+import Notice from '../utils/models/notice';
+import { NoticeData } from '../utils/types/notice';
+import Department from '../utils/models/department';
+import { generateId } from '../utils/helpers/generateId';
+
+export const instance = axios.create();
+
+const crawlIE = async (): Promise<void> => {
+  const NOTICE_SELECTOR =
+    '#block-system-main > div > div > div.view-content > table > tbody > tr';
+  const CREATEDAT_SELECTOR = 'td.views-field.views-field-created';
+  const TITLE_SELECTOR = 'td.views-field.views-field-title-field > a';
+  const URL_SELECTOR = 'td.views-field.views-field-title-field > a';
+  const CONTENT_SELECTOR = 'div.field-items > .field-item';
+
+  const departmentId = '0';
+  const department = await Department.get(departmentId);
+  if (!department) throw new Error(`Department ${departmentId} not exist`);
+  const { url: departmentUrl } = department;
+
+  const boards = await Board.find({ departmentId });
+  if (boards.length === 0)
+    throw new Error(`Board not exist in department [${departmentId}]`);
+
+  console.log(`crawlerBoard start with departmentId [${departmentId}]`);
+
+  const crawlerBoard = async (board: Board) => {
+    const { url: boardUrl, id: boardId } = board;
+    const baseDate = await board.getBaseDate();
+
+    const crawlerPage = async (pageNumber = 0) => {
+      console.log(`crawlerPage start with boardId [${boardId}]`);
+      const noticeHeaders: {
+        url: string;
+        title: string;
+        createdAt: string;
+      }[] = [];
+      const response = await instance.get(`${boardUrl}?page=${pageNumber}`);
+      const html = response.data;
+      const $ = cheerio.load(html);
+      const $notices = $(NOTICE_SELECTOR);
+      await $notices.map(async (_, value) => {
+        const createdAt = $(value).find(CREATEDAT_SELECTOR).text().trim();
+        const title = $(value).find(TITLE_SELECTOR).text().trim();
+        const url = $(value).find(URL_SELECTOR).attr('href')?.trim();
+        noticeHeaders.push({
+          url: departmentUrl + url,
+          title,
+          createdAt,
+        });
+      });
+
+      const noticeData: NoticeData[] = await Promise.all(
+        noticeHeaders.map(async (noticeHeader) => {
+          const id = await generateId(10);
+          const { url, createdAt, title } = noticeHeader;
+          if (createdAt < baseDate) return;
+          const response = await instance.get(url);
+          const html = response.data;
+          const $ = cheerio.load(html);
+          const content = $(CONTENT_SELECTOR).text(); // get full content
+          const noticeData = { id, title, createdAt, content, url, boardId };
+          await Notice.create(noticeData);
+          // eslint-disable-next-line consistent-return
+          return noticeData;
+        })
+      ).then((data) => chain(data).compact().value());
+
+      if (noticeHeaders.length !== noticeData.length) return;
+      await crawlerPage(++pageNumber);
+    };
+
+    await crawlerPage();
+  };
+
+  await Promise.all(
+    boards.map(async (board) => {
+      await crawlerBoard(board);
+    })
+  );
+};
+
+const crawlENG = async (): Promise<void> => {
+  const NOTICE_SELECTOR =
+    '#block-system-main > div > div > div.view-content.hg > table > tbody > tr';
+  const CREATEDAT_SELECTOR =
+    'td.views-field.views-field-created.views-align-center';
+  const TITLE_SELECTOR =
+    'td.views-field.views-field-title.views-align-center.alignLeft > a';
+  const URL_SELECTOR =
+    'td.views-field.views-field-title.views-align-center.alignLeft > a';
+  const CONTENT_SELECTOR =
+    '#block-system-main > div > article > div > div > div > div';
+
+  const departmentId = '1';
+  const department = await Department.get(departmentId);
+  if (!department) throw new Error(`Department ${departmentId} not exist`);
+  const { url: departmentUrl } = department;
+
+  const boards = await Board.find({ departmentId });
+  if (boards.length === 0)
+    throw new Error(`Board not exist in department [${departmentId}]`);
+
+  console.log(`crawlerBoard start with departmentId [${departmentId}]`);
+
+  const crawlerBoard = async (board: Board) => {
+    const { url: boardUrl, id: boardId } = board;
+    const baseDate = await board.getBaseDate();
+
+    const crawlerPage = async (pageNumber = 0) => {
+      console.log(`crawlerPage start with boardId [${boardId}]`);
+      const noticeHeaders: {
+        url: string;
+        title: string;
+        createdAt: string;
+      }[] = [];
+      const response = await instance.get(`${boardUrl}?page=${pageNumber}`);
+      const html = response.data;
+      const $ = cheerio.load(html);
+      const $notices = $(NOTICE_SELECTOR);
+      await $notices.map(async (_, value) => {
+        const isDSK = $(value).attr('class')?.trim();
+        if (isDSK) return;
+        const createdAt = $(value).find(CREATEDAT_SELECTOR).text().trim();
+        const title = $(value).find(TITLE_SELECTOR).text().trim();
+        const url = $(value).find(URL_SELECTOR).attr('href')?.trim();
+        noticeHeaders.push({
+          url: departmentUrl + url,
+          title,
+          createdAt,
+        });
+      });
+
+      const noticeData: NoticeData[] = await Promise.all(
+        noticeHeaders.map(async (noticeHeader) => {
+          const id = await generateId(10);
+          const { url, createdAt, title } = noticeHeader;
+          if (createdAt < baseDate) return;
+          const response = await instance.get(url);
+          const html = response.data;
+          const $ = cheerio.load(html);
+          const content = $(CONTENT_SELECTOR).text(); // get full content
+          const noticeData = { id, title, createdAt, content, url, boardId };
+          await Notice.create(noticeData);
+          // eslint-disable-next-line consistent-return
+          return noticeData;
+        })
+      ).then((data) => chain(data).compact().value());
+
+      if (noticeHeaders.length !== noticeData.length) return;
+      await crawlerPage(++pageNumber);
+    };
+
+    await crawlerPage();
+  };
+
+  await Promise.all(
+    boards.map(async (board) => {
+      await crawlerBoard(board);
+    })
+  );
+};
+
+export const crawl = async (): Promise<void> => {
+  await Promise.all([crawlIE(), crawlENG()]);
+};

--- a/src/crawler/index.ts
+++ b/src/crawler/index.ts
@@ -14,13 +14,13 @@ const crawlIE = async (): Promise<void> => {
     '#block-system-main > div > div > div.view-content > table > tbody > tr';
   const CREATEDAT_SELECTOR = 'td.views-field.views-field-created';
   const TITLE_SELECTOR = 'td.views-field.views-field-title-field > a';
-  const URL_SELECTOR = 'td.views-field.views-field-title-field > a';
+  const URLPATH_SELECTOR = 'td.views-field.views-field-title-field > a';
   const CONTENT_SELECTOR = 'div.field-items > .field-item';
 
   const departmentId = '0';
   const department = await Department.get(departmentId);
   if (!department) throw new Error(`Department ${departmentId} not exist`);
-  const { url: departmentUrl } = department;
+  const { urlPath: departmentUrlPath } = department;
 
   const boards = await Board.find({ departmentId });
   if (boards.length === 0)
@@ -29,26 +29,26 @@ const crawlIE = async (): Promise<void> => {
   console.log(`crawlerBoard start with departmentId [${departmentId}]`);
 
   const crawlerBoard = async (board: Board) => {
-    const { url: boardUrl, id: boardId } = board;
+    const { urlPath: boardUrlPath, id: boardId } = board;
     const baseDate = await board.getBaseDate();
 
     const crawlerPage = async (pageNumber = 0) => {
       console.log(`crawlerPage start with boardId [${boardId}]`);
       const noticeHeaders: {
-        url: string;
+        urlPath: string;
         title: string;
         createdAt: string;
       }[] = [];
-      const response = await instance.get(`${boardUrl}?page=${pageNumber}`);
+      const response = await instance.get(`${boardUrlPath}?page=${pageNumber}`);
       const html = response.data;
       const $ = cheerio.load(html);
       const $notices = $(NOTICE_SELECTOR);
       await $notices.map(async (_, value) => {
         const createdAt = $(value).find(CREATEDAT_SELECTOR).text().trim();
         const title = $(value).find(TITLE_SELECTOR).text().trim();
-        const url = $(value).find(URL_SELECTOR).attr('href')?.trim();
+        const urlPath = $(value).find(URLPATH_SELECTOR).attr('href')?.trim();
         noticeHeaders.push({
-          url: departmentUrl + url,
+          urlPath: departmentUrlPath + urlPath,
           title,
           createdAt,
         });
@@ -57,13 +57,20 @@ const crawlIE = async (): Promise<void> => {
       const noticeData: NoticeData[] = await Promise.all(
         noticeHeaders.map(async (noticeHeader) => {
           const id = await generateId(10);
-          const { url, createdAt, title } = noticeHeader;
+          const { urlPath, createdAt, title } = noticeHeader;
           if (createdAt < baseDate) return;
-          const response = await instance.get(url);
+          const response = await instance.get(urlPath);
           const html = response.data;
           const $ = cheerio.load(html);
           const content = $(CONTENT_SELECTOR).text(); // get full content
-          const noticeData = { id, title, createdAt, content, url, boardId };
+          const noticeData = {
+            id,
+            title,
+            createdAt,
+            content,
+            urlPath,
+            boardId,
+          };
           await Notice.create(noticeData);
           // eslint-disable-next-line consistent-return
           return noticeData;
@@ -91,7 +98,7 @@ const crawlENG = async (): Promise<void> => {
     'td.views-field.views-field-created.views-align-center';
   const TITLE_SELECTOR =
     'td.views-field.views-field-title.views-align-center.alignLeft > a';
-  const URL_SELECTOR =
+  const URLPATH_SELECTOR =
     'td.views-field.views-field-title.views-align-center.alignLeft > a';
   const CONTENT_SELECTOR =
     '#block-system-main > div > article > div > div > div > div';
@@ -99,7 +106,7 @@ const crawlENG = async (): Promise<void> => {
   const departmentId = '1';
   const department = await Department.get(departmentId);
   if (!department) throw new Error(`Department ${departmentId} not exist`);
-  const { url: departmentUrl } = department;
+  const { urlPath: departmentUrlPath } = department;
 
   const boards = await Board.find({ departmentId });
   if (boards.length === 0)
@@ -108,17 +115,17 @@ const crawlENG = async (): Promise<void> => {
   console.log(`crawlerBoard start with departmentId [${departmentId}]`);
 
   const crawlerBoard = async (board: Board) => {
-    const { url: boardUrl, id: boardId } = board;
+    const { urlPath: boardUrlPath, id: boardId } = board;
     const baseDate = await board.getBaseDate();
 
     const crawlerPage = async (pageNumber = 0) => {
       console.log(`crawlerPage start with boardId [${boardId}]`);
       const noticeHeaders: {
-        url: string;
+        urlPath: string;
         title: string;
         createdAt: string;
       }[] = [];
-      const response = await instance.get(`${boardUrl}?page=${pageNumber}`);
+      const response = await instance.get(`${boardUrlPath}?page=${pageNumber}`);
       const html = response.data;
       const $ = cheerio.load(html);
       const $notices = $(NOTICE_SELECTOR);
@@ -127,9 +134,9 @@ const crawlENG = async (): Promise<void> => {
         if (isDSK) return;
         const createdAt = $(value).find(CREATEDAT_SELECTOR).text().trim();
         const title = $(value).find(TITLE_SELECTOR).text().trim();
-        const url = $(value).find(URL_SELECTOR).attr('href')?.trim();
+        const urlPath = $(value).find(URLPATH_SELECTOR).attr('href')?.trim();
         noticeHeaders.push({
-          url: departmentUrl + url,
+          urlPath: departmentUrlPath + urlPath,
           title,
           createdAt,
         });
@@ -138,13 +145,20 @@ const crawlENG = async (): Promise<void> => {
       const noticeData: NoticeData[] = await Promise.all(
         noticeHeaders.map(async (noticeHeader) => {
           const id = await generateId(10);
-          const { url, createdAt, title } = noticeHeader;
+          const { urlPath, createdAt, title } = noticeHeader;
           if (createdAt < baseDate) return;
-          const response = await instance.get(url);
+          const response = await instance.get(urlPath);
           const html = response.data;
           const $ = cheerio.load(html);
           const content = $(CONTENT_SELECTOR).text(); // get full content
-          const noticeData = { id, title, createdAt, content, url, boardId };
+          const noticeData = {
+            id,
+            title,
+            createdAt,
+            content,
+            urlPath,
+            boardId,
+          };
           await Notice.create(noticeData);
           // eslint-disable-next-line consistent-return
           return noticeData;

--- a/src/crawler/index.ts
+++ b/src/crawler/index.ts
@@ -5,7 +5,7 @@ import Board from '../utils/models/board';
 import Notice from '../utils/models/notice';
 import { NoticeData } from '../utils/types/notice';
 import Department from '../utils/models/department';
-import { generateId } from '../utils/helpers/generateId';
+import { generateHash } from '../utils/helpers/generateId';
 
 export const instance = axios.create();
 
@@ -56,8 +56,8 @@ const crawlIE = async (): Promise<void> => {
 
       const noticeData: NoticeData[] = await Promise.all(
         noticeHeaders.map(async (noticeHeader) => {
-          const id = await generateId(10);
           const { urlPath, createdAt, title } = noticeHeader;
+          const id = await generateHash(urlPath);
           if (createdAt < baseDate) return;
           const response = await instance.get(urlPath);
           const html = response.data;
@@ -144,8 +144,8 @@ const crawlENG = async (): Promise<void> => {
 
       const noticeData: NoticeData[] = await Promise.all(
         noticeHeaders.map(async (noticeHeader) => {
-          const id = await generateId(10);
           const { urlPath, createdAt, title } = noticeHeader;
+          const id = await generateHash(urlPath);
           if (createdAt < baseDate) return;
           const response = await instance.get(urlPath);
           const html = response.data;

--- a/src/crawler/middleware.ts
+++ b/src/crawler/middleware.ts
@@ -45,6 +45,7 @@ const middleware = (handler: Handler): APIGatewayProxyHandler => {
         const result = await taskWithTimeout();
         return result;
       } catch (error) {
+        console.log(error);
         error.name = `scheduled ${error.name}`;
         return {
           statusCode: error.statusCode ?? 500,

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -1,5 +1,18 @@
 import { tables } from './table-names';
 
 const { STAGE } = process.env as { STAGE: string };
+const isDevEnv = STAGE === 'dev';
+const { DEV_HTTP_PORT, DEV_LAMBDA_PORT } = process.env;
 
-export const appConfig = { tables, stage: STAGE };
+export const appConfig = {
+  tables,
+  secretKeys: 'snuboard-tyler',
+  stage: STAGE,
+  isDevEnv,
+  httpEndpoint:
+    isDevEnv || !process.env.HTTP_ENDPOINT
+      ? `http://localhost:${DEV_HTTP_PORT}/dev`
+      : process.env.HTTP_ENDPOINT,
+  devLambdaEndpoint: `http://localhost:${DEV_LAMBDA_PORT}`,
+  serviceLaunchedAt: '2021-01-01',
+};

--- a/src/utils/helpers/generateId.ts
+++ b/src/utils/helpers/generateId.ts
@@ -1,0 +1,5 @@
+import { customAlphabet } from 'nanoid';
+
+// Exclude dash or underscore for simplicity
+export const generateId = (size: number): string =>
+  customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', size)();

--- a/src/utils/helpers/generateId.ts
+++ b/src/utils/helpers/generateId.ts
@@ -1,5 +1,12 @@
 import { customAlphabet } from 'nanoid';
+import { Md5 } from 'ts-md5/dist/md5';
 
 // Exclude dash or underscore for simplicity
 export const generateId = (size: number): string =>
   customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', size)();
+
+export const generateHash = (value: string): string => {
+  const hash = Md5.hashStr(value);
+  if (typeof hash === 'string') return hash;
+  throw new Error('type of hash is not string');
+};

--- a/src/utils/helpers/query.ts
+++ b/src/utils/helpers/query.ts
@@ -169,7 +169,7 @@ export const putWithErrorHandling = async (params: {
   ConditionExpression?: string;
 }): Promise<void> => {
   const { Key, Item, TableName, ConditionExpression } = params;
-  const idToCheckFakeConditionalException = generateId(15);
+  const idToCheckFakeConditionalException = generateId(10);
   try {
     await dynamodb
       .put({

--- a/src/utils/helpers/query.ts
+++ b/src/utils/helpers/query.ts
@@ -162,11 +162,12 @@ export const countAll = async (
 };
 
 export const putWithErrorHandling = async (params: {
+  Key: DynamoDB.DocumentClient.Key;
   Item: AttributeMap;
   TableName: string;
   ConditionExpression: string;
 }): Promise<void> => {
-  const { Item, TableName, ConditionExpression } = params;
+  const { Key, Item, TableName, ConditionExpression } = params;
   try {
     await dynamodb
       .put({

--- a/src/utils/models/board.ts
+++ b/src/utils/models/board.ts
@@ -11,7 +11,7 @@ import dynamodb, { AttributeMap } from '../helpers/dynamodb';
 function assertBoardData(data: AttributeMap): asserts data is BoardData {
   const attributes: (keyof BoardData)[] = ['id', 'departmentId', 'name', 'url'];
   const isContainingAttributes = attributes.every((attr) => attr in data);
-  if (isContainingAttributes && typeof data.appData === 'object') {
+  if (isContainingAttributes) {
     return;
   }
   throw new Error('Invalid boardData');

--- a/src/utils/models/board.ts
+++ b/src/utils/models/board.ts
@@ -44,7 +44,9 @@ class Board {
   }
 
   static async create(data: BoardData): Promise<BoardData> {
+    const { id } = data;
     const params = {
+      Key: { id },
       Item: data,
       TableName: TABLE_NAME,
       ConditionExpression: 'attribute_not_exists(id)',

--- a/src/utils/models/board.ts
+++ b/src/utils/models/board.ts
@@ -14,7 +14,12 @@ import dynamodb, { AttributeMap } from '../helpers/dynamodb';
 const { serviceLaunchedAt } = appConfig;
 
 function assertBoardData(data: AttributeMap): asserts data is BoardData {
-  const attributes: (keyof BoardData)[] = ['id', 'departmentId', 'name', 'url'];
+  const attributes: (keyof BoardData)[] = [
+    'id',
+    'departmentId',
+    'name',
+    'urlPath',
+  ];
   const isContainingAttributes = attributes.every((attr) => attr in data);
   if (isContainingAttributes) {
     return;
@@ -40,8 +45,8 @@ class Board {
     return this.data.name;
   }
 
-  get url(): string {
-    return this.data.url;
+  get urlPath(): string {
+    return this.data.urlPath;
   }
 
   getData(): BoardData {

--- a/src/utils/models/board.ts
+++ b/src/utils/models/board.ts
@@ -17,7 +17,7 @@ function assertBoardData(data: AttributeMap): asserts data is BoardData {
   throw new Error('Invalid boardData');
 }
 
-const TABLE_NAME = 'boards';
+const TABLE_NAME = appConfig.tables.board;
 
 class Board {
   // eslint-disable-next-line no-useless-constructor

--- a/src/utils/models/board.ts
+++ b/src/utils/models/board.ts
@@ -9,7 +9,7 @@ import Department from './department';
 import dynamodb, { AttributeMap } from '../helpers/dynamodb';
 
 function assertBoardData(data: AttributeMap): asserts data is BoardData {
-  const attributes: (keyof BoardData)[] = ['id', 'departmentId', 'name', 'uri'];
+  const attributes: (keyof BoardData)[] = ['id', 'departmentId', 'name', 'url'];
   const isContainingAttributes = attributes.every((attr) => attr in data);
   if (isContainingAttributes && typeof data.appData === 'object') {
     return;
@@ -35,8 +35,8 @@ class Board {
     return this.data.name;
   }
 
-  get uri(): string {
-    return this.data.uri;
+  get url(): string {
+    return this.data.url;
   }
 
   getData(): BoardData {

--- a/src/utils/models/department.ts
+++ b/src/utils/models/department.ts
@@ -16,7 +16,7 @@ function assertDepartmentData(
   if (isContainingAttributes) {
     return;
   }
-  throw new Error('Invalid noticeData');
+  throw new Error('Invalid departmentData');
 }
 
 const TABLE_NAME = appConfig.tables.department;

--- a/src/utils/models/department.ts
+++ b/src/utils/models/department.ts
@@ -42,7 +42,9 @@ class Department {
   }
 
   static async create(data: DepartmentData): Promise<DepartmentData> {
+    const { id } = data;
     const params = {
+      Key: { id },
       Item: data,
       TableName: TABLE_NAME,
       ConditionExpression: 'attribute_not_exists(id)',

--- a/src/utils/models/department.ts
+++ b/src/utils/models/department.ts
@@ -13,7 +13,7 @@ function assertDepartmentData(
 ): asserts data is DepartmentData {
   const attributes: (keyof DepartmentData)[] = ['id', 'url', 'name'];
   const isContainingAttributes = attributes.every((attr) => attr in data);
-  if (isContainingAttributes && typeof data.appData === 'object') {
+  if (isContainingAttributes) {
     return;
   }
   throw new Error('Invalid noticeData');

--- a/src/utils/models/department.ts
+++ b/src/utils/models/department.ts
@@ -11,7 +11,7 @@ import dynamodb, { AttributeMap } from '../helpers/dynamodb';
 function assertDepartmentData(
   data: AttributeMap
 ): asserts data is DepartmentData {
-  const attributes: (keyof DepartmentData)[] = ['id', 'url', 'name'];
+  const attributes: (keyof DepartmentData)[] = ['id', 'urlPath', 'name'];
   const isContainingAttributes = attributes.every((attr) => attr in data);
   if (isContainingAttributes) {
     return;
@@ -29,8 +29,8 @@ class Department {
     return this.data.id;
   }
 
-  get url(): string {
-    return this.data.url;
+  get urlPath(): string {
+    return this.data.urlPath;
   }
 
   get name(): string {

--- a/src/utils/models/department.ts
+++ b/src/utils/models/department.ts
@@ -11,7 +11,7 @@ import dynamodb, { AttributeMap } from '../helpers/dynamodb';
 function assertDepartmentData(
   data: AttributeMap
 ): asserts data is DepartmentData {
-  const attributes: (keyof DepartmentData)[] = ['id', 'baseHref', 'name'];
+  const attributes: (keyof DepartmentData)[] = ['id', 'url', 'name'];
   const isContainingAttributes = attributes.every((attr) => attr in data);
   if (isContainingAttributes && typeof data.appData === 'object') {
     return;
@@ -29,8 +29,8 @@ class Department {
     return this.data.id;
   }
 
-  get baseHref(): string {
-    return this.data.baseHref;
+  get url(): string {
+    return this.data.url;
   }
 
   get name(): string {

--- a/src/utils/models/notice.ts
+++ b/src/utils/models/notice.ts
@@ -14,7 +14,7 @@ function assertNoticeData(data: AttributeMap): asserts data is NoticeData {
     'createdAt',
     'title',
     'boardId',
-    'url',
+    'urlPath',
   ];
   const isContainingAttributes = attributes.every((attr) => attr in data);
   if (isContainingAttributes) {
@@ -50,8 +50,8 @@ class Notice {
     return this.data.content;
   }
 
-  get url(): string {
-    return this.data.url;
+  get urlPath(): string {
+    return this.data.urlPath;
   }
 
   getData(): NoticeData {

--- a/src/utils/models/notice.ts
+++ b/src/utils/models/notice.ts
@@ -59,10 +59,11 @@ class Notice {
   }
 
   static async create(data: NoticeData): Promise<NoticeData> {
+    const { createdAt, title } = data;
     const params = {
+      Key: { createdAt, title },
       Item: data,
       TableName: TABLE_NAME,
-      ConditionExpression: 'attribute_not_exists(id)',
     };
 
     await putWithErrorHandling(params);

--- a/src/utils/models/notice.ts
+++ b/src/utils/models/notice.ts
@@ -17,7 +17,7 @@ function assertNoticeData(data: AttributeMap): asserts data is NoticeData {
     'url',
   ];
   const isContainingAttributes = attributes.every((attr) => attr in data);
-  if (isContainingAttributes && typeof data.appData === 'object') {
+  if (isContainingAttributes) {
     return;
   }
   throw new Error('Invalid noticeData');

--- a/src/utils/models/notice.ts
+++ b/src/utils/models/notice.ts
@@ -14,8 +14,7 @@ function assertNoticeData(data: AttributeMap): asserts data is NoticeData {
     'createdAt',
     'title',
     'boardId',
-    'content',
-    'href',
+    'url',
   ];
   const isContainingAttributes = attributes.every((attr) => attr in data);
   if (isContainingAttributes && typeof data.appData === 'object') {
@@ -42,7 +41,7 @@ class Notice {
     return this.data.title;
   }
 
-  get boardId(): number {
+  get boardId(): string {
     return this.data.boardId;
   }
 
@@ -51,8 +50,8 @@ class Notice {
     return this.data.content;
   }
 
-  get href(): string {
-    return this.data.href;
+  get url(): string {
+    return this.data.url;
   }
 
   getData(): NoticeData {

--- a/src/utils/models/notice.ts
+++ b/src/utils/models/notice.ts
@@ -59,15 +59,14 @@ class Notice {
   }
 
   static async create(data: NoticeData): Promise<NoticeData> {
-    const { createdAt, title } = data;
+    const { id } = data;
     const params = {
-      Key: { createdAt, title },
+      Key: { id },
       Item: data,
       TableName: TABLE_NAME,
+      ConditionExpression: 'attribute_not_exists(id)',
     };
-
     await putWithErrorHandling(params);
-
     return new Notice(data);
   }
 

--- a/src/utils/types/board.ts
+++ b/src/utils/types/board.ts
@@ -2,5 +2,5 @@ export interface BoardData {
   id: string;
   departmentId: string;
   name: string;
-  uri: string;
+  url: string;
 }

--- a/src/utils/types/board.ts
+++ b/src/utils/types/board.ts
@@ -2,5 +2,5 @@ export interface BoardData {
   id: string;
   departmentId: string;
   name: string;
-  url: string;
+  urlPath: string;
 }

--- a/src/utils/types/department.ts
+++ b/src/utils/types/department.ts
@@ -1,5 +1,5 @@
 export interface DepartmentData {
   id: string;
-  baseHref: string;
+  url: string;
   name: string;
 }

--- a/src/utils/types/department.ts
+++ b/src/utils/types/department.ts
@@ -1,5 +1,5 @@
 export interface DepartmentData {
   id: string;
-  url: string;
+  urlPath: string;
   name: string;
 }

--- a/src/utils/types/notice.ts
+++ b/src/utils/types/notice.ts
@@ -3,6 +3,6 @@ export interface NoticeData {
   createdAt: string;
   title: string;
   boardId: string;
-  url: string;
+  urlPath: string;
   content?: string;
 }

--- a/src/utils/types/notice.ts
+++ b/src/utils/types/notice.ts
@@ -2,7 +2,7 @@ export interface NoticeData {
   id: string;
   createdAt: string;
   title: string;
-  boardId: number;
+  boardId: string;
+  url: string;
   content?: string;
-  href: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2402,6 +2402,21 @@ aws-sdk@^2.624.0, aws-sdk@^2.7.0, aws-sdk@^2.834.0, aws-sdk@^2.838.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
+aws-sdk@^2.756.0:
+  version "2.839.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.839.0.tgz#74e9697e5dcb2d116032363ad80f5b705759fafb"
+  integrity sha512-CFgiZ8IUpI1Qqs0ECheGO592lvGG6dYp7SsMJ5Xegd+aBAn6dimPTSmrnkPHPyzFhMYtBx1kE6SxVkl9MKOcWg==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -7505,6 +7520,11 @@ nanoid@^2.1.0:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
   integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
 
+nanoid@^3.1.20:
+  version "3.1.20"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
+  integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -9276,6 +9296,14 @@ serialize-javascript@^5.0.1:
   dependencies:
     randombytes "^2.1.0"
 
+serverless-domain-manager@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/serverless-domain-manager/-/serverless-domain-manager-5.1.0.tgz#44c975b4adeac6b32507c92313ee001735d56c55"
+  integrity sha512-uGLGr9nWTupimWxVwz/2S/fK+YULsg8hQ0ZddS1DNerzctIVQBXVbLMGUJv34a9a5HV0YPvVqCA/JBNI7VOSvA==
+  dependencies:
+    aws-sdk "^2.756.0"
+    chalk "^4.1.0"
+
 serverless-dynamodb-local@^0.2.39:
   version "0.2.39"
   resolved "https://registry.yarnpkg.com/serverless-dynamodb-local/-/serverless-dynamodb-local-0.2.39.tgz#9022bb8fa5d2271b1959bf8728b03c8680e66ca2"
@@ -10425,6 +10453,11 @@ ts-loader@^8.0.15:
     loader-utils "^2.0.0"
     micromatch "^4.0.0"
     semver "^7.3.4"
+
+ts-md5@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/ts-md5/-/ts-md5-1.2.7.tgz#b76471fc2fd38f0502441f6c3b9494ed04537401"
+  integrity sha512-emODogvKGWi1KO1l9c6YxLMBn6CEH3VrH5mVPIyOtxBG52BvV4jP3GWz6bOZCz61nLgBc3ffQYE4+EHfCD+V7w==
 
 "ts-node@>= 8.3.0":
   version "9.1.1"


### PR DESCRIPTION
# commits
- serverless 설정을 좀 바꿔줬습니다. 9288f8b
- attribute 이름을 좀 바꿔줬습니다. 3de26bb
- assert 하는 과정에서 appData라는 게 없는데 체크하고 있었습니다... 다른 데서 코드 복붙해오는 과정에서 발견을 못했습니다. aaf3205
- put 연산할 때 `Conditional Check failed exception` 관련하여 에러 핸들링이 필요해서 put 연산할 때 Key를 요구합니다. 781b433
- 잘못된 에러 메시지를 수정하고, 테이블 이름도 제대로 된 이름으로 고쳐줍니다. a9b1628
- AWS DynamoDB의 `Conditional Check failed exception` 에러 관련하여 핸들링을 해줍니다. b1b4018
- 산업공학과, 공과대학 크롤러를 실행하는 Lambda 함수를 추가합니다. 두 함수는 몇줄 빼고는(Selector들과 isDSK 부분 빼고는) 같습니다. 그래서 아예 합칠 수도 있었지만, 앞으로 학과를 계속 추가하면 크롤러 구조가 계속 달라질 것 같아서 일단 독립된 함수들로 만들었습니다. 아직 코드를 추상화하여 아름답게 만들 단계는 아니라고 판단했습니다. c4d9dc7

# 추가
- 다음 두 가지 상황을 막기 위한 조치를 합니다. 1) test에 배포해야 할 걸 실수로 product로 배포한다. 2) stage name에 오타를 내서 인프라를 새로 만든다. 84fd6c9
- 크롤러 돌려보니까 메모리 512MB까지는 필요 없어서 320으로 줄였습니다. 256은 좀 타이트한 것 같아서 320으로 했어요. ea41213
- dynamoDB conditionExpression에서 `url`이 reserved keyword라고 하네요. 현재, url을 conditionExpression에 쓰는 곳은 없긴 한데, 나중에 문제가 될 수 있을 것 같아서 미리 이름을 `urlPath`로 바꿉니다. 9195ea6
- dynamoDB에 공지사항(notice) 데이터를 삽입할 때 일부가 누락되거나 또는 크롤러를 다시 돌렸을 때 같은 게 또 들어가는 중복 문제가 있었는데 이를 해결합니다. 원래는 `id`를 길이만 고정하고 string을 랜덤하게 뽑아서 사용했는데, urlPath의 hash 값을 이용하도록 했습니다.
- fake conditional check exception을 해결하는 데 굳이 길이 15짜리 id를 쓸 필요는 없을 것 같아서 10으로 줄였습니다. 사실 더 줄여도 되는데... 12ae827
- yarn.lock 파일을 업데이트합니다. aeeacc3

# 테스트
- test 서버에 배포하고 크롤러가 잘 돌아가는 것을 확인했습니다.